### PR TITLE
throw specific catchable error on malformed urls

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -1,10 +1,16 @@
+
 var Router = require('./router')
+var errors = require('./errors')
 
 Router.prototype.dispatcher = function () {
   var trie = this.trie
 
   return function* trieRouter (next) {
-    var match = trie.match(this.request.path)
+    try {
+      var match = trie.match(this.request.path)
+    } catch (err) {
+      throw new errors.MalformedUrl(err)
+    }
     var node = match && match.node
     // If no route match or no methods are defined, go to next middleware
     // TODO: make node.methods more well-defined

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,9 @@
+
+var errors = require('errors')
+
+errors.create({
+  name: 'MalformedUrl',
+  defaultMessage: 'Attempted to match a malformed URL',
+  code: 1101,
+  scope: module.exports
+})

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
   "license": "MIT",
   "repository": "koajs/trie-router",
   "dependencies": {
-    "methods": "1",
+    "errors": "^0.3.0",
     "flatten": "0",
     "is-gen-fn": "0",
-    "routington": "1",
-    "koa-compose": "2"
+    "koa-compose": "2",
+    "methods": "1",
+    "routington": "1"
   },
   "devDependencies": {
     "koa": "0",
@@ -25,9 +26,9 @@
     "istanbul-harmony": "0"
   },
   "scripts": {
-    "test": "mocha --harmony-generators --reporter spec --require should",
-    "test-cov": "node --harmony-generators node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should",
-    "test-travis": "node --harmony-generators node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --require should"
+    "test": "mocha --harmony --reporter spec --require should",
+    "test-cov": "node --harmony node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --require should",
+    "test-travis": "node --harmony node_modules/.bin/istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --reporter dot --require should"
   },
   "files": [
     "lib"

--- a/test/routes.js
+++ b/test/routes.js
@@ -6,7 +6,6 @@ var assert = require('assert')
 var koa = require('koa')
 
 var router = require('..')
-var errors = require('../lib/errors')
 
 var app = koa()
 

--- a/test/routes.js
+++ b/test/routes.js
@@ -6,6 +6,7 @@ var assert = require('assert')
 var koa = require('koa')
 
 var router = require('..')
+var errors = require('../lib/errors')
 
 var app = koa()
 
@@ -173,6 +174,16 @@ describe('404', function(){
     .get('/app')
     .expect(404, done)
   })
+})
+
+it('should throw for malformed url', function (done) {
+  app.get('/', function* (next) {
+    this.status = 204
+  })
+
+  request(server)
+  .get('/%')
+  .expect(500, done)
 })
 
 describe('regressions', function () {


### PR DESCRIPTION
Alternative to PR #20
Alike @th507, I had to make some changes to the tests to run on Node 4.x.x. Goal here was to "throw a very specific error with an `err.code` that you could try/catch upstream" that @jonathanong suggested in the original, seemingly inactive, PR. I used the `errors` module for this... but let me know if you'd like me to switch it out for a standard custom `Error` constructor (first look how nice this module is!).

**Before merging-**
I'd also like to catch that specific error thrown in the tests if possible to make them a bit clearer and tighter... but can't quite figure that part out.
Tried-
```javascript
request(server)
.get('/%')
.expect(500, function(err, res) {
  assert.ifError(err)
})
```
... but kept getting complaints about excessive timeouts. not really familiar with this setup- any ideas?