### PR TITLE
Allow middlewares to be used for options requests

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -155,13 +155,6 @@ class Router {
   [__MIDDLEWARE](ctx, next) {
     let {method} = ctx
 
-    // OPTIONS support
-    if (method === 'OPTIONS') {
-      ctx.response.status = 204
-      ctx.response.set('Allow', this.methods.toString())
-      return
-    }
-
     let match
     try {
       match = this.trie.match(ctx.request.path)
@@ -179,12 +172,36 @@ class Router {
     let middle = getMiddleware(this.methods, method) // router[method](fn)
     let bottom = getMiddleware(node.methods, method) // router[method](path, fn)
 
-    let stack = [...top, ...middle, preBottom.bind(this), ...bottom]
+    let stack = [
+      ...top,
+      preMiddle.bind(this),
+       ...middle,
+       preBottom.bind(this),
+       ...bottom
+    ]
 
     let fn = compose(stack)
     return fn(ctx, noop)
 
     // ----------------
+
+    /**
+     * OPTIONS support
+     * we want to provide a default OPTIONS handler for any path
+     * so we set all the required headers and HTTP status here
+     * and we give middleware functions a chance to overwrite them
+     * then, in the `preBottom` function, we'll return this status
+     * (or the value it was overwritten with) if no middleware
+     * handles this path
+     */
+    function preMiddle(ctx, goToMiddleMiddleware) {
+      if (method === 'OPTIONS') {
+        ctx.response.status = 204
+        ctx.response.set('Allow', this.methods.toString())
+      }
+
+      return goToMiddleMiddleware()
+    }
 
     function preBottom(ctx, goToBottomMiddleware) {
       // If no route match or no methods are defined, go to next middleware
@@ -193,7 +210,11 @@ class Router {
       }
       // If there is no one middleware
       // it's a 405 error
-      if (!bottom.length) {
+      //
+      // normally we'd return a 405 here since no route handles this path
+      // but we provide a default OPTIONS handler
+      // we've set all of the necessary headers and HTTP statuses in the `preMiddle` function
+      if (!bottom.length && method !== 'OPTIONS') {
         ctx.response.set('Allow', this.methods.toString())
         ctx.response.status = 405
         return

--- a/test/routes.js
+++ b/test/routes.js
@@ -173,6 +173,20 @@ describe('router[method]()', function () {
       .get('/one')
       .status(204)
   })
+
+  it('calls OPTIONS middleware', function () {
+    let expectedOrigin = 'https://example.com'
+
+    router.options(function (ctx) {
+      ctx.status = 200
+      ctx.set('Access-Control-Allow-Origin', expectedOrigin)
+    })
+
+    return request.options('/')
+      .status(200)
+      .header('Access-Control-Allow-Origin', expectedOrigin)
+  })
+
 })
 
 
@@ -282,6 +296,19 @@ describe('router[method](path, [fn...])', function () {
         .get('/stack/three')
         .status(204)
     })
+  })
+
+  it('calls OPTIONS middleware', function () {
+    let expectedOrigin = 'https://example.com'
+
+    router.options('/', function (ctx) {
+      ctx.status = 200
+      ctx.set('Access-Control-Allow-Origin', expectedOrigin)
+    })
+
+    return request.options('/')
+      .status(200)
+      .header('Access-Control-Allow-Origin', expectedOrigin)
   })
 })
 
@@ -401,5 +428,3 @@ describe('regressions', function () {
     })
   })
 })
-
-


### PR DESCRIPTION
This PR allows custom middleware functions to be defined for options requests. It should fix this issue https://github.com/koajs/trie-router/issues/40